### PR TITLE
fix: set content type to application/json

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -67,6 +67,7 @@ function callES(server, url, method, data, successCallback, completeCallback) {
     $.ajax({
         url: url,
         data: method == "GET" ? null : data,
+        contentType: 'application/json',
 //      xhrFields: {
 //            withCredentials: true
 //      },


### PR DESCRIPTION
ElasticSearch 6.0 accept only content type application/json

#3