### PR TITLE
fix: add Content-Type header to POST requests.

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -68,6 +68,7 @@ function callES(server, url, method, data, successCallback, completeCallback) {
         url: url,
         data: method == "GET" ? null : data,
         contentType: 'application/json',
+		headers: method == "GET" ? null : { "Content-Type": "application/json" },
 //      xhrFields: {
 //            withCredentials: true
 //      },


### PR DESCRIPTION
This is required due to changes in Elasticsearch 6.x - strict content-type checking:
https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests